### PR TITLE
Update v8-profiler-next

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "v8-profiler-next": "1.4.2"
+  "v8-profiler-next": "1.9.0"
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Ran into a problem starting an application due to [v8-profiler-next](https://github.com/hyj1991/v8-profiler-next) and when I updated it, it worked.

![monti_apm](https://github.com/monti-apm/meteor-agent-binary-deps/assets/6644545/d353cb70-55c3-4606-b89d-f39051d2b433)
